### PR TITLE
Minor change to prevent gcc -Weffc++ warnings. 

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -294,6 +294,9 @@ namespace detail {
 // which arguments are formatted.
 class FormatIterator
 {
+    // FormatIterator contains a pointer so set the copy constructor private (prevent warning with gcc and -Weffc++)
+    FormatIterator(const FormatIterator&);
+    FormatIterator& operator=(const FormatIterator&);
     public:
         // Flags for features not representable with standard stream state
         enum ExtraFormatFlags


### PR DESCRIPTION
Hi c42f, 

I like your tool, thanks for that!
I did not know that there is such a small implementation to use std::string with the s/printf syntax, which I prefer over std::stringstream. 

We use in our project -Weffc++ and usually build warnings free. I thought instead of branching here permanently, I send you the two lines to prevent the warnings as pull request, perhaps you want to apply it.

Cheers
Uli
