### PR TITLE
Fix tests for %p on 64-bit Windows with MSVC

### DIFF
--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -124,21 +124,30 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%s", "asdf_123098"), "asdf_123098");
     // Note: All tests printing pointers are different on windows, since
     // there's no standard numerical representation.
+    // Representation also differs between 32-bit and 64-bit windows.
 #   ifdef _MSC_VER
+#   ifdef _WIN64
+    CHECK_EQUAL(tfm::format("%p", (void*)0x12345), "0000000000012345");
+#   else
     CHECK_EQUAL(tfm::format("%p", (void*)0x12345), "00012345");
+#   endif // _WIN64
 #   else
     CHECK_EQUAL(tfm::format("%p", (void*)0x12345), "0x12345");
-#   endif
+#   endif // _MSC_VER
     CHECK_EQUAL(tfm::format("%%%s", "asdf"), "%asdf"); // note: plain "%%" format gives warning with gcc
     // chars with int format specs are printed as ints:
     CHECK_EQUAL(tfm::format("%hhd", (char)65), "65");
     CHECK_EQUAL(tfm::format("%hhu", (unsigned char)65), "65");
     CHECK_EQUAL(tfm::format("%hhd", (signed char)65), "65");
 #   ifdef _MSC_VER
+#   ifdef _WIN64
+    CHECK_EQUAL(tfm::format("%p", (const char*)0x10), "0000000000000010");
+#   else
     CHECK_EQUAL(tfm::format("%p", (const char*)0x10), "00000010");
+#   endif // _WIN64
 #   else
     CHECK_EQUAL(tfm::format("%p", (const char*)0x10), "0x10"); // should print address, not string.
-#   endif
+#   endif // _MSC_VER
     // bools with string format spec are printed as "true" or "false"
     CHECK_EQUAL(tfm::format("%s", true), "true");
     CHECK_EQUAL(tfm::format("%d", true), "1");


### PR DESCRIPTION
On 64-bit Windows, pointer representation is padded with even more zeros than on 32-bit.
