### PR TITLE
Fix formatting integers with both precision and the sign flag set

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -686,6 +686,7 @@ inline const char* FormatIterator::streamStateFromFormat(std::ostream& out,
     extraFlags = Flag_None;
     bool precisionSet = false;
     bool widthSet = false;
+    int widthExtra = 0;
     const char* c = fmtStart + 1;
     // 1) Parse flags
     for(;; ++c)
@@ -717,6 +718,7 @@ inline const char* FormatIterator::streamStateFromFormat(std::ostream& out,
             case '+':
                 out.setf(std::ios::showpos);
                 extraFlags &= ~Flag_SpacePadPositive;
+                widthExtra = 1;
                 continue;
         }
         break;
@@ -832,7 +834,7 @@ inline const char* FormatIterator::streamStateFromFormat(std::ostream& out,
         // padded with zeros on the left).  This isn't really supported by the
         // iostreams, but we can approximately simulate it with the width if
         // the width isn't otherwise used.
-        out.width(out.precision());
+        out.width(out.precision() + widthExtra);
         out.setf(std::ios::internal, std::ios::adjustfield);
         out.fill('0');
     }

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -167,6 +167,9 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%#010X", 0xBEEF), "0X0000BEEF");
     CHECK_EQUAL(tfm::format("% d",  10), " 10");
     CHECK_EQUAL(tfm::format("% d", -10), "-10");
+    // Test flags with variable precision & width
+    CHECK_EQUAL(tfm::format("%+.2d", 3), "+03");
+    CHECK_EQUAL(tfm::format("%+.2d", -3), "-03");
     // flag override precedence
     CHECK_EQUAL(tfm::format("%+ d", 10), "+10"); // '+' overrides ' '
     CHECK_EQUAL(tfm::format("% +d", 10), "+10");


### PR DESCRIPTION
Format strings such as "%+.2d" were not properly padded with zero.
