### PR TITLE
fix VS2013 warnings

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -310,8 +310,8 @@ inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,
     // void* respectively and format that instead of the value itself.  For the
     // %p conversion it's important to avoid dereferencing the pointer, which
     // could otherwise lead to a crash when printing a dangling (const char*).
-    const bool canConvertToChar = detail::is_convertible<T,char>::value;
-    const bool canConvertToVoidPtr = detail::is_convertible<T, const void*>::value;
+    bool canConvertToChar = detail::is_convertible<T,char>::value;
+    bool canConvertToVoidPtr = detail::is_convertible<T, const void*>::value;
     if(canConvertToChar && *(fmtEnd-1) == 'c')
         detail::formatValueAsType<T, char>::invoke(out, value);
     else if(canConvertToVoidPtr && *(fmtEnd-1) == 'p')
@@ -539,7 +539,7 @@ inline int parseIntAndAdvance(const char*& c)
 inline const char* printFormatStringLiteral(std::ostream& out, const char* fmt)
 {
     const char* c = fmt;
-    for(; true; ++c)
+    for(;; ++c)
     {
         switch(*c)
         {


### PR DESCRIPTION
This pull request fixes warnings produced by VS2013
tinyformat.h(315): warning C4127: conditional expression is constant
tinyformat.h(542): warning C4127: conditional expression is constant

Warning Level - Level4 (/W4)
