### PR TITLE
fix VS2013 with TINYFORMAT_USE_VARIADIC_TEMPLATES enabled

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -149,6 +149,11 @@ namespace tfm = tinyformat;
 
 #ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
 #   include <array>
+#   if defined(_MSC_VER) && _MSC_VER <= 1800 // VS2013
+#       define TINYFORMAT_BRACED_INIT_WORKAROUND(x) (x)
+#   else
+#       define TINYFORMAT_BRACED_INIT_WORKAROUND(x) x
+#   endif
 #endif
 
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20080201
@@ -851,15 +856,7 @@ class FormatListN : public FormatList
         template<typename... Args>
         FormatListN(const Args&... args)
             : FormatList(&m_formatterStore[0], N),
-            m_formatterStore
-// VS2013 needs a pair of extra braces to compile
-#ifdef _MSC_VER
-(
-#endif
-            {FormatArg(args)...}
-#ifdef _MSC_VER
-)
-#endif
+            m_formatterStore TINYFORMAT_BRACED_INIT_WORKAROUND({ FormatArg(args)... })
         { static_assert(sizeof...(args) == N, "Number of args must be N"); }
 #else // C++98 version
         void init(int) {}

--- a/tinyformat.h
+++ b/tinyformat.h
@@ -147,6 +147,10 @@ namespace tfm = tinyformat;
 #   endif
 #endif
 
+#ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
+#   include <array>
+#endif
+
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20080201
 //  std::showpos is broken on old libstdc++ as provided with OSX.  See
 //  http://gcc.gnu.org/ml/libstdc++/2007-11/msg00075.html
@@ -847,7 +851,15 @@ class FormatListN : public FormatList
         template<typename... Args>
         FormatListN(const Args&... args)
             : FormatList(&m_formatterStore[0], N),
-            m_formatterStore{FormatArg(args)...}
+            m_formatterStore
+// VS2013 needs a pair of extra braces to compile
+#ifdef _MSC_VER
+(
+#endif
+            {FormatArg(args)...}
+#ifdef _MSC_VER
+)
+#endif
         { static_assert(sizeof...(args) == N, "Number of args must be N"); }
 #else // C++98 version
         void init(int) {}
@@ -870,7 +882,11 @@ class FormatListN : public FormatList
 #endif
 
     private:
+#ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
+        std::array<FormatArg, N> m_formatterStore;
+#else // C++98 version
         FormatArg m_formatterStore[N];
+#endif
 };
 
 // Special 0-arg version - MSVC says zero-sized C array in struct is nonstandard


### PR DESCRIPTION
This pull request fixes error produced by VS2013 when TINYFORMAT_USE_VARIADIC_TEMPLATES is defined

    error C2536: 'tinyformat::detail::FormatListN<1>::tinyformat::detail::FormatListN<1>::m_formatterStore' : cannot specify explicit initializer for arrays

VS2013 doesn't like when

    FormatArg m_formatterStore[N];

is initialized like this:

     m_formatterStore{FormatArg(args)...}

more on this here: http://stackoverflow.com/questions/19877757/workaround-for-error-c2536-cannot-specify-explicit-initializer-for-arrays-in-vi

VS2013 also needs `std::array` instead of plain C array to make it work.
I have run tests with clang and VS2013, looks good.
