### PR TITLE
Fix for VS2015: _set_output_format() is no longer available nor needed.

### DIFF
--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -100,7 +100,7 @@ std::ostream& operator<<(std::ostream& os, const MyInt& obj) {
 int unitTests()
 {
     int nfailed = 0;
-#   ifdef _MSC_VER
+#   if defined(_MSC_VER) && _MSC_VER < 1900 // VC++ older than 2015
     // floats are printed with three digit exponents on windows, which messes
     // up the tests.  Turn this off for consistency:
     _set_output_format(_TWO_DIGIT_EXPONENT);


### PR DESCRIPTION
_set_output_format() has been intentionally removed from VS2015, and the output is now standard-conforming according to <https://connect.microsoft.com/VisualStudio/feedback/details/1368280>.