### PR TITLE
Fix useless cast

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -552,10 +552,10 @@ inline const char* printFormatStringLiteral(std::ostream& out, const char* fmt)
         switch(*c)
         {
             case '\0':
-                out.write(fmt, static_cast<std::streamsize>(c - fmt));
+                out.write(fmt, c - fmt);
                 return c;
             case '%':
-                out.write(fmt, static_cast<std::streamsize>(c - fmt));
+                out.write(fmt, c - fmt);
                 if(*(c+1) != '%')
                     return c;
                 // for "%%", tack trailing % onto next literal section.

--- a/tinyformat.h
+++ b/tinyformat.h
@@ -561,6 +561,8 @@ inline const char* printFormatStringLiteral(std::ostream& out, const char* fmt)
                 // for "%%", tack trailing % onto next literal section.
                 fmt = ++c;
                 break;
+            default:
+                break;
         }
     }
 }
@@ -630,6 +632,8 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
                 spacePadPositive = false;
                 widthExtra = 1;
                 continue;
+            default:
+                break;
         }
         break;
     }
@@ -743,6 +747,8 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
             TINYFORMAT_ERROR("tinyformat: Conversion spec incorrectly "
                              "terminated by end of string");
             return c;
+        default:
+            break;
     }
     if(intConversion && precisionSet && !widthSet)
     {


### PR DESCRIPTION
When compiling on Ubuntu 14.04 with gcc 4.8.4 with -Wuseless-cast I get this:

    tinyformat.h:555:68: error: useless cast to type ‘std::streamsize {aka long int}’ [-Werror=useless-cast]
                     out.write(fmt, static_cast<std::streamsize>(c - fmt));
                                                                    ^
    tinyformat.h:558:68: error: useless cast to type ‘std::streamsize {aka long int}’ [-Werror=useless-cast]
                     out.write(fmt, static_cast<std::streamsize>(c - fmt));
                                                                    ^

Also fix warnings produced by adding `-Wswitch-default`