### PR TITLE
Fixed bug with copying of FormatListN object as an object of class Fo…

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -842,6 +842,7 @@ class FormatList
                             const FormatList& list);
 
     private:
+        FormatList(const FormatList& other);
         const detail::FormatArg* m_formatters;
         int m_N;
 };
@@ -857,6 +858,11 @@ template<int N>
 class FormatListN : public FormatList
 {
     public:
+        FormatListN(const FormatListN<N>& other)
+              :FormatList(&m_formatterStore[0], N)
+        {
+              std::copy(other.m_formatterStore, other.m_formatterStore+N, m_formatterStore);
+        }
 #ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
         template<typename... Args>
         FormatListN(const Args&... args)
@@ -890,7 +896,11 @@ class FormatListN : public FormatList
 // Special 0-arg version - MSVC says zero-sized C array in struct is nonstandard
 template<> class FormatListN<0> : public FormatList
 {
-    public: FormatListN() : FormatList(0, 0) {}
+    public:
+        FormatListN() : FormatList(0, 0) {}
+        FormatListN(const FormatListN<0>& other)
+             :FormatList(0, 0)
+        {}
 };
 
 } // namespace detail


### PR DESCRIPTION
On the intel compiler, version 15.0.5.223 there appears to be a bug in tinyformat.h. The attached patch fixes it. 

Due to the ridiculous amount of templating it's hard for me to be sure, but I believe that an object of class detail::FormatListN is being copied as an object of class FormatList. The original FormatListN object is then deleted, and the copied FormatList now contains an invalid pointer.

This may be compiler specific.