### PR TITLE
nullptr initialisation of FormatArg pointers, runtime debug mode checks

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -487,7 +487,11 @@ namespace detail {
 class FormatArg
 {
     public:
-        FormatArg() {}
+        FormatArg()
+            : m_value(nullptr),
+            m_formatImpl(nullptr),
+            m_toIntImpl(nullptr)
+        { }
 
         template<typename T>
         FormatArg(const T& value)
@@ -499,11 +503,15 @@ class FormatArg
         void format(std::ostream& out, const char* fmtBegin,
                     const char* fmtEnd, int ntrunc) const
         {
+            assert(m_value);
+            assert(m_formatImpl);
             m_formatImpl(out, fmtBegin, fmtEnd, ntrunc, m_value);
         }
 
         int toInt() const
         {
+            assert(m_value);
+            assert(m_toIntImpl);
             return m_toIntImpl(m_value);
         }
 
@@ -839,6 +847,7 @@ inline void formatImpl(std::ostream& out, const char* fmt,
 class FormatList
 {
     public:
+        FormatList() = delete;
         FormatList(detail::FormatArg* formatters, int N)
             : m_formatters(formatters), m_N(N) { }
 

--- a/tinyformat.h
+++ b/tinyformat.h
@@ -488,9 +488,9 @@ class FormatArg
 {
     public:
         FormatArg()
-            : m_value(nullptr),
-            m_formatImpl(nullptr),
-            m_toIntImpl(nullptr)
+            : m_value(NULL),
+            m_formatImpl(NULL),
+            m_toIntImpl(NULL)
         { }
 
         template<typename T>
@@ -847,7 +847,6 @@ inline void formatImpl(std::ostream& out, const char* fmt,
 class FormatList
 {
     public:
-        FormatList() = delete;
         FormatList(detail::FormatArg* formatters, int N)
             : m_formatters(formatters), m_N(N) { }
 
@@ -855,6 +854,7 @@ class FormatList
                             const FormatList& list);
 
     private:
+        FormatList();
         const detail::FormatArg* m_formatters;
         int m_N;
 };


### PR DESCRIPTION
Proposed fix for Issue #42 

Initialise FormatArg pointers in default constructor, runtime assertions.