### PR TITLE
New TINYFORMAT_ASSERT() macro

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -137,6 +137,10 @@ namespace tfm = tinyformat;
 #include <iostream>
 #include <sstream>
 
+#ifndef TINYFORMAT_ASSERT
+#   define TINYFORMAT_ASSERT(cond) assert(cond)
+#endif
+
 #ifndef TINYFORMAT_ERROR
 #   define TINYFORMAT_ERROR(reason) assert(0 && reason)
 #endif
@@ -210,7 +214,7 @@ template<int n> struct is_wchar<wchar_t[n]> {};
 template<typename T, typename fmtT, bool convertible = is_convertible<T, fmtT>::value>
 struct formatValueAsType
 {
-    static void invoke(std::ostream& /*out*/, const T& /*value*/) { assert(0); }
+    static void invoke(std::ostream& /*out*/, const T& /*value*/) { TINYFORMAT_ASSERT(0); }
 };
 // Specialized version for types that can actually be converted to fmtT, as
 // indicated by the "convertible" template parameter.
@@ -503,15 +507,15 @@ class FormatArg
         void format(std::ostream& out, const char* fmtBegin,
                     const char* fmtEnd, int ntrunc) const
         {
-            assert(m_value);
-            assert(m_formatImpl);
+            TINYFORMAT_ASSERT(m_value);
+            TINYFORMAT_ASSERT(m_formatImpl);
             m_formatImpl(out, fmtBegin, fmtEnd, ntrunc, m_value);
         }
 
         int toInt() const
         {
-            assert(m_value);
-            assert(m_toIntImpl);
+            TINYFORMAT_ASSERT(m_value);
+            TINYFORMAT_ASSERT(m_toIntImpl);
             return m_toIntImpl(m_value);
         }
 
@@ -877,18 +881,18 @@ class FormatListN : public FormatList
         { static_assert(sizeof...(args) == N, "Number of args must be N"); }
 #else // C++98 version
         void init(int) {}
-#       define TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR(n)       \
-                                                               \
-        template<TINYFORMAT_ARGTYPES(n)>                       \
-        FormatListN(TINYFORMAT_VARARGS(n))                     \
-            : FormatList(&m_formatterStore[0], n)              \
-        { assert(n == N); init(0, TINYFORMAT_PASSARGS(n)); }   \
-                                                               \
-        template<TINYFORMAT_ARGTYPES(n)>                       \
-        void init(int i, TINYFORMAT_VARARGS(n))                \
-        {                                                      \
-            m_formatterStore[i] = FormatArg(v1);               \
-            init(i+1 TINYFORMAT_PASSARGS_TAIL(n));             \
+#       define TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR(n)                \
+                                                                        \
+        template<TINYFORMAT_ARGTYPES(n)>                                \
+        FormatListN(TINYFORMAT_VARARGS(n))                              \
+            : FormatList(&m_formatterStore[0], n)                       \
+        { TINYFORMAT_ASSERT(n == N); init(0, TINYFORMAT_PASSARGS(n)); } \
+                                                                        \
+        template<TINYFORMAT_ARGTYPES(n)>                                \
+        void init(int i, TINYFORMAT_VARARGS(n))                         \
+        {                                                               \
+            m_formatterStore[i] = FormatArg(v1);                        \
+            init(i+1 TINYFORMAT_PASSARGS_TAIL(n));                      \
         }
 
         TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR)


### PR DESCRIPTION
to support use cases where calling assert() is undesired

Reference: https://github.com/RcppCore/Rcpp/issues/786#issuecomment-350580035