### PR TITLE
Include cassert only if necessary

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -133,15 +133,16 @@ namespace tfm = tinyformat;
 //------------------------------------------------------------------------------
 // Implementation details.
 #include <algorithm>
-#include <cassert>
 #include <iostream>
 #include <sstream>
 
 #ifndef TINYFORMAT_ASSERT
+#   include <cassert>
 #   define TINYFORMAT_ASSERT(cond) assert(cond)
 #endif
 
 #ifndef TINYFORMAT_ERROR
+#   include <cassert>
 #   define TINYFORMAT_ERROR(reason) assert(0 && reason)
 #endif
 


### PR DESCRIPTION
I'm not sure if this the right thing to do. There are advantages to having a stable set of included files.

Thanks for the very quick review of #48!