### PR TITLE
Added support for format specifier represented as string object

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -976,6 +976,16 @@ std::string format(const char* fmt, const Args&... args)
     return oss.str();
 }
 
+/// Format list of arguments according to the given format in a string object and return
+/// the result as a string.
+template<typename... Args>
+std::string format(const std::string& fmt, const Args&... args)
+{
+    std::ostringstream oss;
+    format(oss, fmt.c_str(), args...);
+    return oss.str();
+}
+
 /// Format list of arguments to std::cout, according to the given format string
 template<typename... Args>
 void printf(const char* fmt, const Args&... args)


### PR DESCRIPTION
Once you're working with std::string objects, if you're creating composite format specifiers, most likely they'll be already in std::string. So why not to support them? Small addition - big convenience.