### PR TITLE
Add support for %a,%A format specifiers - hex float output  #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,9 @@ Here's a list of known incompatibilities:
 
 * The `"%a"` and `"%A"` hexadecimal floating point conversions ignore precision
   as stream output of hexfloat (introduced in C++11) ignores precision, always
-  outputting the minimum number of digits required for exact representation
-  (MSVC incorrectly honors stream precision - the default precision of 6 digits
-  risks losing precision by truncation so to guarantee lossless roundtrip
-  conversion "%.13a" will output full precision padded with 0's as needed).
+  outputting the minimum number of digits required for exact representation.
+  MSVC incorrectly honors stream precision, so we force precision to 13 in this
+  case to guarentee lossless roundtrip conversion.
 * The precision for integer conversions cannot be supported by the iostreams
   state independently of the field width.  (Note: **this is only a
   problem for certain obscure integer conversions**; float conversions like

--- a/README.md
+++ b/README.md
@@ -191,9 +191,12 @@ means that a `bool` variable printed with "%s" will come out as `true` or
 Not all features of printf can be simulated simply using standard iostreams.
 Here's a list of known incompatibilities:
 
-* The C99 `"%a"` and `"%A"` hexadecimal floating point conversions are not
-  supported since the iostreams don't have the necessary flags.  Using either
-  of these flags will result in a call to `TINYFORMAT_ERROR`.
+* The `"%a"` and `"%A"` hexadecimal floating point conversions ignore precision
+  as stream output of hexfloat (introduced in C++11) ignores precision, always
+  outputting the minimum number of digits required for exact representation
+  (MSVC incorrectly honors stream precision - the default precision of 6 digits
+  risks losing precision by truncation so to guarantee lossless roundtrip
+  conversion "%.13a" will output full precision padded with 0's as needed).
 * The precision for integer conversions cannot be supported by the iostreams
   state independently of the field width.  (Note: **this is only a
   problem for certain obscure integer conversions**; float conversions like

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,5 +48,5 @@ build_script:
 
 test_script:
   # cmake testall target has problems finding the correct configuration, so use ctest directly.
-  - ctest -C %CONFIGURATION%
+  - ctest -VV -C %CONFIGURATION%
 

--- a/tinyformat.h
+++ b/tinyformat.h
@@ -739,6 +739,12 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
             out.setf(std::ios::uppercase);
             // Falls through
         case 'a':
+#           ifdef _MSC_VER
+            // Workaround https://developercommunity.visualstudio.com/content/problem/520472/hexfloat-stream-output-does-not-ignore-precision-a.html
+            // by always setting maximum precision on MSVC to avoid precision
+            // loss for doubles.
+            out.precision(13);
+#           endif
             out.setf(std::ios::fixed | std::ios::scientific, std::ios::floatfield);
             break;
         case 'G':

--- a/tinyformat.h
+++ b/tinyformat.h
@@ -487,7 +487,7 @@ namespace detail {
 
 // Type-opaque holder for an argument to format(), with associated actions on
 // the type held as explicit function pointers.  This allows FormatArg's for
-// each argument to be allocated as a homogenous array inside FormatList
+// each argument to be allocated as a homogeneous array inside FormatList
 // whereas a naive implementation based on inheritance does not.
 class FormatArg
 {
@@ -735,6 +735,12 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
         case 'f':
             out.setf(std::ios::fixed, std::ios::floatfield);
             break;
+        case 'A':
+            out.setf(std::ios::uppercase);
+            // Falls through
+        case 'a':
+            out.setf(std::ios::fixed | std::ios::scientific, std::ios::floatfield);
+            break;
         case 'G':
             out.setf(std::ios::uppercase);
             // Falls through
@@ -743,17 +749,13 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
             // As in boost::format, let stream decide float format.
             out.flags(out.flags() & ~std::ios::floatfield);
             break;
-        case 'a': case 'A':
-            TINYFORMAT_ERROR("tinyformat: the %a and %A conversion specs "
-                             "are not supported");
-            break;
         case 'c':
             // Handled as special case inside formatValue()
             break;
         case 's':
             if(precisionSet)
                 ntrunc = static_cast<int>(out.precision());
-            // Make %s print booleans as "true" and "false"
+            // Make %s print Booleans as "true" and "false"
             out.setf(std::ios::boolalpha);
             break;
         case 'n':

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -122,6 +122,8 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%E", -1.23456E10), "-1.234560E+10");
     CHECK_EQUAL(tfm::format("%f", -9.8765), "-9.876500");
     CHECK_EQUAL(tfm::format("%F", 9.8765), "9.876500");
+    CHECK_EQUAL(tfm::format("%a", -9.75), "-0x1.38p+3");
+    CHECK_EQUAL(tfm::format("%A", 9.75), "0X1.38P+3");
     CHECK_EQUAL(tfm::format("%g", 10), "10");
     CHECK_EQUAL(tfm::format("%G", 100), "100");
     CHECK_EQUAL(tfm::format("%c", 65), "A");
@@ -163,6 +165,8 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%.4d", 10), "0010");
     CHECK_EQUAL(tfm::format("%10.4f", 1234.1234567890), " 1234.1235");
     CHECK_EQUAL(tfm::format("%.f", 10.1), "10");
+    CHECK_EQUAL(tfm::format("%.a", -9.75), "-0x1.38p+3"); // precision ignored for hex float as required
+    CHECK_EQUAL(tfm::format("%10a", 9.75), " 0x1.38p+3");
     CHECK_EQUAL(tfm::format("%.2s", "asdf"), "as"); // strings truncate to precision
     CHECK_EQUAL(tfm::format("%.2s", std::string("asdf")), "as");
 //    // Test variable precision & width
@@ -227,8 +231,6 @@ int unitTests()
 
     // Unhandled C99 format spec
     EXPECT_ERROR( tfm::format("%n", 10) )
-    EXPECT_ERROR( tfm::format("%a", 10) )
-    EXPECT_ERROR( tfm::format("%A", 10) )
 
 #ifdef TEST_WCHAR_T_COMPILE
     // Test wchar_t handling - should fail to compile!

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -165,8 +165,9 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%.4d", 10), "0010");
     CHECK_EQUAL(tfm::format("%10.4f", 1234.1234567890), " 1234.1235");
     CHECK_EQUAL(tfm::format("%.f", 10.1), "10");
-    CHECK_EQUAL(tfm::format("%14a", 1.671111047267913818359375), " 0x1.abcdefp+0");
-    CHECK_EQUAL(tfm::format("%.2s", "asdf"), "as"); // strings truncate to precision
+	CHECK_EQUAL(tfm::format("%.13a", 0.1), "0x1.999999999999ap-4");
+	CHECK_EQUAL(tfm::format("%14a", 1.671111047267913818359375), " 0x1.abcdefp+0");
+	CHECK_EQUAL(tfm::format("%.2s", "asdf"), "as"); // strings truncate to precision
     CHECK_EQUAL(tfm::format("%.2s", std::string("asdf")), "as");
 //    // Test variable precision & width
     CHECK_EQUAL(tfm::format("%*.4f", 10, 1234.1234567890), " 1234.1235");

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -122,8 +122,8 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%E", -1.23456E10), "-1.234560E+10");
     CHECK_EQUAL(tfm::format("%f", -9.8765), "-9.876500");
     CHECK_EQUAL(tfm::format("%F", 9.8765), "9.876500");
-    CHECK_EQUAL(tfm::format("%a", -9.75), "-0x1.38p+3");
-    CHECK_EQUAL(tfm::format("%A", 9.75), "0X1.38P+3");
+    CHECK_EQUAL(tfm::format("%a", -1.671111047267913818359375), "-0x1.abcdefp+0");
+    CHECK_EQUAL(tfm::format("%A", 1.671111047267913818359375), "0X1.ABCDEFP+0");
     CHECK_EQUAL(tfm::format("%g", 10), "10");
     CHECK_EQUAL(tfm::format("%G", 100), "100");
     CHECK_EQUAL(tfm::format("%c", 65), "A");
@@ -165,8 +165,8 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%.4d", 10), "0010");
     CHECK_EQUAL(tfm::format("%10.4f", 1234.1234567890), " 1234.1235");
     CHECK_EQUAL(tfm::format("%.f", 10.1), "10");
-    CHECK_EQUAL(tfm::format("%.a", -9.75), "-0x1.38p+3"); // precision ignored for hex float as required
-    CHECK_EQUAL(tfm::format("%10a", 9.75), " 0x1.38p+3");
+    CHECK_EQUAL(tfm::format("%.a", -1.671111047267913818359375), "-0x1.abcdefp+0"); // precision ignored for hex float as required
+    CHECK_EQUAL(tfm::format("%14a", 1.671111047267913818359375), " 0x1.abcdefp+0");
     CHECK_EQUAL(tfm::format("%.2s", "asdf"), "as"); // strings truncate to precision
     CHECK_EQUAL(tfm::format("%.2s", std::string("asdf")), "as");
 //    // Test variable precision & width

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -165,9 +165,18 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%.4d", 10), "0010");
     CHECK_EQUAL(tfm::format("%10.4f", 1234.1234567890), " 1234.1235");
     CHECK_EQUAL(tfm::format("%.f", 10.1), "10");
-	CHECK_EQUAL(tfm::format("%.13a", 0.1), "0x1.999999999999ap-4");
-	CHECK_EQUAL(tfm::format("%14a", 1.671111047267913818359375), " 0x1.abcdefp+0");
-	CHECK_EQUAL(tfm::format("%.2s", "asdf"), "as"); // strings truncate to precision
+    CHECK_EQUAL(tfm::format("%.13a", 0.1), "0x1.999999999999ap-4");
+    CHECK_EQUAL(tfm::format("%14a", 1.671111047267913818359375), " 0x1.abcdefp+0");
+    // Per C++ spec, iostreams ignore the precision for "%a" to avoid precision
+    // loss. This is a printf incompatibility.
+#   ifndef _MSC_VER
+    CHECK_EQUAL(tfm::format("%a", 1.13671875), "0x1.23p+0");
+    CHECK_EQUAL(tfm::format("%.6a", 1.13671875), "0x1.23p+0");
+#   else
+    CHECK_EQUAL(tfm::format("%a", 1.13671875), "0x1.2300000000000p+0");
+    CHECK_EQUAL(tfm::format("%.6a", 1.13671875), "0x1.2300000000000p+0");
+#   endif
+    CHECK_EQUAL(tfm::format("%.2s", "asdf"), "as"); // strings truncate to precision
     CHECK_EQUAL(tfm::format("%.2s", std::string("asdf")), "as");
 //    // Test variable precision & width
     CHECK_EQUAL(tfm::format("%*.4f", 10, 1234.1234567890), " 1234.1235");

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -165,7 +165,6 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%.4d", 10), "0010");
     CHECK_EQUAL(tfm::format("%10.4f", 1234.1234567890), " 1234.1235");
     CHECK_EQUAL(tfm::format("%.f", 10.1), "10");
-    CHECK_EQUAL(tfm::format("%.a", -1.671111047267913818359375), "-0x1.abcdefp+0"); // precision ignored for hex float as required
     CHECK_EQUAL(tfm::format("%14a", 1.671111047267913818359375), " 0x1.abcdefp+0");
     CHECK_EQUAL(tfm::format("%.2s", "asdf"), "as"); // strings truncate to precision
     CHECK_EQUAL(tfm::format("%.2s", std::string("asdf")), "as");

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -170,14 +170,15 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%.4d", 10), "0010");
     CHECK_EQUAL(tfm::format("%10.4f", 1234.1234567890), " 1234.1235");
     CHECK_EQUAL(tfm::format("%.f", 10.1), "10");
-    CHECK_EQUAL(tfm::format("%.13a", 0.1), "0x1.999999999999ap-4");
-    CHECK_EQUAL(tfm::format("%14a", 1.671111047267913818359375), " 0x1.abcdefp+0");
     // Per C++ spec, iostreams ignore the precision for "%a" to avoid precision
     // loss. This is a printf incompatibility.
 #   ifndef _MSC_VER
     CHECK_EQUAL(tfm::format("%.1a", 1.13671875), "0x1.23p+0");
+    CHECK_EQUAL(tfm::format("%14a", 1.671111047267913818359375), " 0x1.abcdefp+0");
 #   else
+    // MSVC workaround
     CHECK_EQUAL(tfm::format("%.1a", 1.13671875), "0x1.2300000000000p+0");
+    CHECK_EQUAL(tfm::format("%21a", 1.671111047267913818359375), " 0x1.abcdef0000000p+0");
 #   endif
     CHECK_EQUAL(tfm::format("%.2s", "asdf"), "as"); // strings truncate to precision
     CHECK_EQUAL(tfm::format("%.2s", std::string("asdf")), "as");

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -122,8 +122,13 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%E", -1.23456E10), "-1.234560E+10");
     CHECK_EQUAL(tfm::format("%f", -9.8765), "-9.876500");
     CHECK_EQUAL(tfm::format("%F", 9.8765), "9.876500");
+#   ifndef _MSC_VER
     CHECK_EQUAL(tfm::format("%a", -1.671111047267913818359375), "-0x1.abcdefp+0");
-    CHECK_EQUAL(tfm::format("%A", 1.671111047267913818359375), "0X1.ABCDEFP+0");
+    CHECK_EQUAL(tfm::format("%A",  1.671111047267913818359375),  "0X1.ABCDEFP+0");
+#   else
+    CHECK_EQUAL(tfm::format("%a", -1.671111047267913818359375), "-0x1.abcdef0000000p+0");
+    CHECK_EQUAL(tfm::format("%A",  1.671111047267913818359375),  "0X1.ABCDEF0000000P+0");
+#   endif
     CHECK_EQUAL(tfm::format("%g", 10), "10");
     CHECK_EQUAL(tfm::format("%G", 100), "100");
     CHECK_EQUAL(tfm::format("%c", 65), "A");
@@ -170,11 +175,9 @@ int unitTests()
     // Per C++ spec, iostreams ignore the precision for "%a" to avoid precision
     // loss. This is a printf incompatibility.
 #   ifndef _MSC_VER
-    CHECK_EQUAL(tfm::format("%a", 1.13671875), "0x1.23p+0");
-    CHECK_EQUAL(tfm::format("%.6a", 1.13671875), "0x1.23p+0");
+    CHECK_EQUAL(tfm::format("%.1a", 1.13671875), "0x1.23p+0");
 #   else
-    CHECK_EQUAL(tfm::format("%a", 1.13671875), "0x1.2300000000000p+0");
-    CHECK_EQUAL(tfm::format("%.6a", 1.13671875), "0x1.2300000000000p+0");
+    CHECK_EQUAL(tfm::format("%.1a", 1.13671875), "0x1.2300000000000p+0");
 #   endif
     CHECK_EQUAL(tfm::format("%.2s", "asdf"), "as"); // strings truncate to precision
     CHECK_EQUAL(tfm::format("%.2s", std::string("asdf")), "as");


### PR DESCRIPTION
Add tests for formatted output, width modifier and precision (ignored).
(Only tested on recent GCC so please test with the CI targets.)