### PR TITLE
Fix UB introduced by copying detail::FormatListN objects.

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -984,6 +984,11 @@ class FormatListN : public FormatList
         TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR)
 #       undef TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR
 #endif
+        FormatListN(const FormatListN& other)
+            : FormatList(&m_formatterStore[0], N)
+        { std::copy(const_cast<FormatArg*>(&other.m_formatterStore[0]),
+                    const_cast<FormatArg*>(&other.m_formatterStore[N]),
+                    &m_formatterStore[0]); }
 
     private:
         FormatArg m_formatterStore[N];

--- a/tinyformat.h
+++ b/tinyformat.h
@@ -986,8 +986,7 @@ class FormatListN : public FormatList
 #endif
         FormatListN(const FormatListN& other)
             : FormatList(&m_formatterStore[0], N)
-        { std::copy(const_cast<FormatArg*>(&other.m_formatterStore[0]),
-                    const_cast<FormatArg*>(&other.m_formatterStore[N]),
+        { std::copy(&other.m_formatterStore[0], &other.m_formatterStore[N],
                     &m_formatterStore[0]); }
 
     private:


### PR DESCRIPTION
When copying a `detail::FormatListN` object, the *m_formatterStore* must also be copied, otherwise the pointer in the parent `FormatList` class are possibly invalid.

This addresses the segfault explained in #58. The issue arises when `makeFormatList` returns an object which holds a pointer to memory created for the temporary object on the stack.
