### PR TITLE
Fix: type of FormatListN template parameter

### DIFF
--- a/tinyformat.h
+++ b/tinyformat.h
@@ -957,7 +957,7 @@ typedef const FormatList& FormatListRef;
 namespace detail {
 
 // Format list subclass with fixed storage to avoid dynamic allocation
-template<int N>
+template<std::size_t N>
 class FormatListN : public FormatList
 {
     public:


### PR DESCRIPTION
The fix changes type of FormatListN template parameter from int to std::size_t.

I assume that FormatListN template parameter is allways non-negative integer number. And sizeof... operator returns a constant of type std::size_t.

Without the fix and with strict gcc compiler settings we get:
```
tinyformat.h:1019:21: error: conversion from ‘long unsigned int’ to ‘int’ may change value [-Werror=conversion]
 1019 | detail::FormatListN<sizeof...(Args)> makeFormatList(const Args&... args)
      |                     ^~~~~~~~~~~~~~~
tinyformat.h: In function ‘tinyformat::detail::FormatListN<sizeof... (Args)> tinyformat::makeFormatList(const Args& ...)’:
tinyformat.h:1021:32: error: conversion from ‘long unsigned int’ to ‘int’ may change value [-Werror=conversion]
 1021 |     return detail::FormatListN<sizeof...(args)>(args...);
```
Fix solves the problem reported by gcc. But solution is not 100% correct. The N is passed to the  FormatList constructor that takes and stores `int`.
So, may be we get next message from compiler in the future (eg. from newer compiler). Correct is to store N to `std::size_t`.
Or if we want to save some memory, use `int` and add `static_cast<int>`.

When I think more about it. Maybe it's a compiler error. It knows the value of N at compile time, so it shouldn't report errors / warnings that something could happen. It can't happened in my compiled code.
Huh, I'm confused now.