### PR TITLE
Fix incorrect zero padding of inf and NaN

### DIFF
--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -11,6 +11,7 @@ namespace std { class type_info; }
 
 #include <stdexcept>
 #include <climits>
+#include <limits>
 #include <cfloat>
 #include <cstddef>
 
@@ -212,6 +213,13 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%1$10.*2$f", 1234.1234567890, 4), " 1234.1235");
     CHECK_EQUAL(tfm::format("%1$*3$.*2$f", 1234.1234567890, 4, 10), " 1234.1235");
     CHECK_EQUAL(tfm::format("%1$*2$.*3$f", 1234.1234567890, -10, 4), "1234.1235 ");
+    // Test padding for infinity and NaN
+    CHECK_EQUAL(tfm::format("%.3d",   std::numeric_limits<double>::infinity()), "inf");
+    CHECK_EQUAL(tfm::format("%.4d",   std::numeric_limits<double>::infinity()), " inf");
+    CHECK_EQUAL(tfm::format("%04.0f", std::numeric_limits<double>::infinity()), " inf");
+    CHECK_EQUAL(tfm::format("%.3d",   std::numeric_limits<double>::quiet_NaN()), "nan");
+    CHECK_EQUAL(tfm::format("%.4d",   std::numeric_limits<double>::quiet_NaN()), " nan");
+    CHECK_EQUAL(tfm::format("%04.0f", std::numeric_limits<double>::quiet_NaN()), " nan");
 
     //------------------------------------------------------------
     // Test flags

--- a/tinyformat_test.cpp
+++ b/tinyformat_test.cpp
@@ -214,12 +214,15 @@ int unitTests()
     CHECK_EQUAL(tfm::format("%1$*3$.*2$f", 1234.1234567890, 4, 10), " 1234.1235");
     CHECK_EQUAL(tfm::format("%1$*2$.*3$f", 1234.1234567890, -10, 4), "1234.1235 ");
     // Test padding for infinity and NaN
+    // (Visual Studio 12.0 and earlier print these in a different way)
+#   if !defined(_MSC_VER) || _MSC_VER >= 1900
     CHECK_EQUAL(tfm::format("%.3d",   std::numeric_limits<double>::infinity()), "inf");
     CHECK_EQUAL(tfm::format("%.4d",   std::numeric_limits<double>::infinity()), " inf");
     CHECK_EQUAL(tfm::format("%04.0f", std::numeric_limits<double>::infinity()), " inf");
     CHECK_EQUAL(tfm::format("%.3d",   std::numeric_limits<double>::quiet_NaN()), "nan");
     CHECK_EQUAL(tfm::format("%.4d",   std::numeric_limits<double>::quiet_NaN()), " nan");
     CHECK_EQUAL(tfm::format("%04.0f", std::numeric_limits<double>::quiet_NaN()), " nan");
+#   endif
 
     //------------------------------------------------------------
     // Test flags


### PR DESCRIPTION
We now follow the rule: if the type is a non-finite floating point type,
*and* the stream fill has been zero padded, then reset it to ' '.

This prevents zero-padded numbers which turn out to be nan/inf from
being oddly formatted with leading zeros.

Should fix #76