### PR TITLE
Add missing inline to fix multiple definition error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
+_empty.cpp
 _bloat_test_tmp*
 tinyformat_test_cxx*
 tinyformat_speed_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,10 @@ if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /WX")
 endif()
 
-add_executable(tinyformat_test tinyformat_test.cpp)
+# Dummy translation unit to test for missing `inline`s
+include_directories(${CMAKE_SOURCE_DIR})
+file(WRITE ${CMAKE_BINARY_DIR}/_empty.cpp "#include \"tinyformat.h\"")
+add_executable(tinyformat_test tinyformat_test.cpp ${CMAKE_BINARY_DIR}/_empty.cpp)
 enable_testing()
 if(CMAKE_CONFIGURATION_TYPES)
     set(ctest_config_opt -C ${CMAKE_BUILD_TYPE})

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,15 @@ speed_test: tinyformat_speed_test
 	@echo boost timings:
 	@time -p ./tinyformat_speed_test boost > /dev/null
 
-tinyformat_test_cxx98: tinyformat.h tinyformat_test.cpp Makefile
-	$(CXX) $(CXXFLAGS) -std=c++98 -DTINYFORMAT_NO_VARIADIC_TEMPLATES tinyformat_test.cpp -o tinyformat_test_cxx98
+# To test for multiple definitions
+_empty.cpp:
+	echo '#include "tinyformat.h"' > _empty.cpp
 
-tinyformat_test_cxx11: tinyformat.h tinyformat_test.cpp Makefile
-	$(CXX) $(CXXFLAGS) $(CXX11FLAGS) -DTINYFORMAT_USE_VARIADIC_TEMPLATES tinyformat_test.cpp -o tinyformat_test_cxx11
+tinyformat_test_cxx98: tinyformat.h tinyformat_test.cpp _empty.cpp Makefile
+	$(CXX) $(CXXFLAGS) -std=c++98 -DTINYFORMAT_NO_VARIADIC_TEMPLATES _empty.cpp tinyformat_test.cpp -o tinyformat_test_cxx98
+
+tinyformat_test_cxx11: tinyformat.h tinyformat_test.cpp _empty.cpp Makefile
+	$(CXX) $(CXXFLAGS) $(CXX11FLAGS) -DTINYFORMAT_USE_VARIADIC_TEMPLATES _empty.cpp tinyformat_test.cpp -o tinyformat_test_cxx11
 
 tinyformat.html: README.rst
 	@echo building docs...

--- a/tinyformat.h
+++ b/tinyformat.h
@@ -302,11 +302,11 @@ template<typename T>
 void spaceFillIfNotFinite(std::ostream& out, const T& value) { }
 // TODO: type_traits would clearly be better here. Should consider moving all
 // these workarounds into a big pre-C++11 section.
-#define TINYFORMAT_SETFILL_NOT_FINITE_FLOATING(type)        \
-void spaceFillIfNotFinite(std::ostream& out, type value)    \
-{                                                           \
-    if (out.fill() == '0' && !std::isfinite(value))         \
-        out.fill(' ');                                      \
+#define TINYFORMAT_SETFILL_NOT_FINITE_FLOATING(type)             \
+inline void spaceFillIfNotFinite(std::ostream& out, type value)  \
+{                                                                \
+    if (out.fill() == '0' && !std::isfinite(value))              \
+        out.fill(' ');                                           \
 }
 TINYFORMAT_SETFILL_NOT_FINITE_FLOATING(float)
 TINYFORMAT_SETFILL_NOT_FINITE_FLOATING(double)


### PR DESCRIPTION
Also add a separate dummy translation unit to the tests to ensure this
doesn't happen again.

Fixes #79 